### PR TITLE
Make export templates path generic and relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@
 This is the Dudelings `1.2.1` repo project folder for `Godot 3.6`.
 
 # Running & Building
-In order to run this version of Dudelings, you need [GodotSteam version 3.6](https://github.com/GodotSteam/GodotSteam/releases/tag/v3.28) and the [export templates](https://github.com/GodotSteam/GodotSteam/releases/download/v3.28/godotsteam-g36-s161-gs328-templates.zip).
 
+## Prerequisite 1
+In order to run this version of Dudelings, you need [GodotSteam 3.28 for Godot 3.6](https://github.com/GodotSteam/GodotSteam/releases/tag/v3.28) and the matching [export templates](https://github.com/GodotSteam/GodotSteam/releases/download/v3.28/godotsteam-g36-s161-gs328-templates.zip) (same GitHub release).
+
+If you don't want to change the path in the project file, place the extracted templates archive into the same directory where you are going to clone this repo (see Step 1).
+
+## Prerequisite 2
 You'll need a [retail copy of Dudelings: Arcade Sportsball](https://heavy-element.itch.io/dudelings) in order to debug, run, and build this repo.
 
 ## Step 1:

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -13,8 +13,8 @@ script_encryption_key=""
 
 [preset.0.options]
 
-custom_template/debug="/home/gbryant/.local/share/godot/templates/3.6.stable/godotsteam.36.debug.template.windows.32.exe"
-custom_template/release="/home/gbryant/.local/share/godot/templates/3.6.stable/godotsteam.36.debug.template.windows.64.exe"
+custom_template/debug="../godotsteam-g36-s161-gs328-templates/godotsteam.36.debug.template.windows.32.exe"
+custom_template/release="../godotsteam-g36-s161-gs328-templates/godotsteam.36.debug.template.windows.64.exe"
 binary_format/64_bits=true
 binary_format/embed_pck=true
 texture_format/bptc=false
@@ -51,14 +51,14 @@ custom_features=""
 export_filter="all_resources"
 include_filter=""
 exclude_filter=""
-export_path="../builds/dudelings_linux_build.x86_64"
+export_path="../dudelings-builds/linux/dudelings_linux_build_x86_64"
 script_export_mode=1
 script_encryption_key=""
 
 [preset.1.options]
 
-custom_template/debug="/home/gbryant/.local/share/godot/templates/3.6.stable/godotsteam.36.debug.template.linux.64"
-custom_template/release="/home/gbryant/.local/share/godot/templates/3.6.stable/godotsteam.36.template.linux.64"
+custom_template/debug="../godotsteam-g36-s161-gs328-templates/godotsteam.36.debug.template.linux.64"
+custom_template/release="../godotsteam-g36-s161-gs328-templates/godotsteam.36.template.linux.64"
 binary_format/architecture="x86_64"
 binary_format/embed_pck=true
 texture_format/bptc=false


### PR DESCRIPTION
Extrating to a parallel directory is easier than using the XDG Godot directory. GodotSteam will also download the Godot templates and not the GodotSteam templates into the XDG-chosen dir if initiated from inside the editor, so it seems easier/clearer to keep the GodotSteam ones separate.